### PR TITLE
Renamed Filable trait to HasFiles

### DIFF
--- a/src/Concerns/HasFiles.php
+++ b/src/Concerns/HasFiles.php
@@ -19,9 +19,9 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  *
  * @mixin Model
  */
-trait Fileable
+trait HasFiles
 {
-    public static function bootFileable(): void
+    public static function bootHasFiles(): void
     {
         static::deleting(static function (self $model): ?bool {
             if (array_key_exists(SoftDeletes::class, class_uses_recursive($model))) {

--- a/src/Models/File.php
+++ b/src/Models/File.php
@@ -2,9 +2,8 @@
 
 namespace Astrotomic\Fileable\Models;
 
-use Astrotomic\Fileable\Concerns\Fileable;
 use Astrotomic\Fileable\Contracts\File as FileContract;
-use Astrotomic\Fileable\Contracts\Fileable as FileableContract;
+use Astrotomic\Fileable\Contracts\Fileable;
 use Astrotomic\LaravelEloquentUuid\Eloquent\Concerns\UsesUUID;
 use Closure;
 use Illuminate\Contracts\Filesystem\Filesystem;
@@ -44,7 +43,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  * @method static Builder|File query()
  * @method static Builder|MorphMany|File whereCreatedAt($value)
  * @method static Builder|MorphMany|File whereDisk($value)
- * @method static Builder|MorphMany|File whereFileable(FileableContract $fileable)
+ * @method static Builder|MorphMany|File whereFileable(Fileable $fileable)
  * @method static Builder|MorphMany|File whereFileableId($value)
  * @method static Builder|MorphMany|File whereFileableType($value)
  * @method static Builder|MorphMany|File whereFilename($value)
@@ -106,11 +105,11 @@ class File extends Model implements Responsable, FileContract
 
     /**
      * @param Builder $query
-     * @param FileableContract|Model $fileable
+     * @param Fileable|Model $fileable
      *
      * @return Builder
      */
-    public function scopeWhereFileable(Builder $query, FileableContract $fileable): Builder
+    public function scopeWhereFileable(Builder $query, Fileable $fileable): Builder
     {
         return $query->where(
             fn (Builder $q) => $q

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -2,11 +2,11 @@
 
 namespace Astrotomic\Fileable\Tests\Models;
 
-use Astrotomic\Fileable\Concerns\Fileable;
-use Astrotomic\Fileable\Contracts\Fileable as FileableContract;
+use Astrotomic\Fileable\Concerns\HasFiles;
+use Astrotomic\Fileable\Contracts\Fileable;
 use Illuminate\Database\Eloquent\Model;
 
-class Post extends Model implements FileableContract
+class Post extends Model implements Fileable
 {
-    use Fileable;
+    use HasFiles;
 }


### PR DESCRIPTION
This pr renames the `Fileable` trait to `HasFiles` as discussed in https://github.com/Astrotomic/laravel-fileable/issues/1. (closes https://github.com/Astrotomic/laravel-fileable/issues/1)