### PR TITLE
Add .phpunit.result.cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /phpunit.xml
 /.coverage/
+.phpunit.result.cache


### PR DESCRIPTION
This pr adds the `.phpunit.result.cache` to the gitignored files.